### PR TITLE
feat: add user data loading to dashboard

### DIFF
--- a/src/APIs/UsersService.ts
+++ b/src/APIs/UsersService.ts
@@ -1,6 +1,6 @@
 import { AuthApiError, RegApiError } from '../utils/errors';
-import { Authorization, AuthResponse, PlayedTest, Registration, User, UsersCookie } from 'utils/types';
-import { getCookie, setCookie } from '../../node_modules/typescript-cookie'
+import { Authorization, AuthResponse, PlayedTest, Registration, User, UserData } from 'utils/types';
+import { getCookie, setCookie, removeCookie } from '../../node_modules/typescript-cookie'
 import { json } from 'stream/consumers';
 
 const url: string = 'https://rscloneserver.onrender.com';
@@ -36,7 +36,7 @@ export class UsersService{
 
     const user = await this.getUser(user_id);
 
-    const cookie: UsersCookie = {
+    const cookie: UserData = {
       userId: user_id,
       userName: user.user_name,
       regDate: new Date(user.registration_date),
@@ -47,9 +47,13 @@ export class UsersService{
     setCookie('user', JSON.stringify(cookie), {expires: 7, path: ''});
   }
 
-  static getCookie(): UsersCookie{
+  static getCookie(): UserData{
     const cookie = getCookie('user')
     return JSON.parse(cookie? cookie : 'false');
+  }
+
+  static removeCookie(){
+    removeCookie('user');
   }
 
   // Returns interval between registration and now in milliseconds

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -10,7 +10,7 @@ export class App {
       pageId = 'main';
       window.location.hash = 'main';
     } else {
-      pageId = window.location.hash.slice(1);
+      pageId = window.location.hash.slice(1).split("/")[0];
     }
     build(routerPaths[pageId]);
   }

--- a/src/app/build.ts
+++ b/src/app/build.ts
@@ -3,6 +3,8 @@ import { HeaderComponent } from '../components/header/header';
 import { pageMarkup } from 'interfaces/paths';
 
 export async function build(page: pageMarkup): Promise<void> {
+  console.log(page);
+  
   const main: HTMLElement = document.createElement('main');
   main.classList.add('main');
   document.body.innerHTML = '';

--- a/src/app/router.ts
+++ b/src/app/router.ts
@@ -2,6 +2,8 @@ import { build } from './build';
 import { routerPaths } from './routerPaths';
 
 export const router = async (): Promise<void> => {
-  let hash = window.location.hash.slice(1);
-  await build(routerPaths[hash]);
+  let hash = window.location.hash.slice(1).split('/');
+  console.log(hash[0]);
+  
+  await build(routerPaths[hash[0]]);
 };

--- a/src/components/header/header.ts
+++ b/src/components/header/header.ts
@@ -4,12 +4,14 @@ import { lang } from '../translate/translate';
 import { state } from '../../utils/state';
 import { App } from '../../app/app';
 import { Component } from '../../components/component';
+import { UsersService } from '../../APIs/UsersService';
 
 export class HeaderComponent implements Component {
 
   async getHtml(): Promise<string> {
     const path = state.isEngl ? lang.en : lang.ru;
     const btnInner = state.isEngl ? 'РУС' : 'ENG';
+    const cookie = UsersService.getCookie();
     return `<header class="top-nav">
     <div><a class='top-nav-svg' href="#main">${lang.en.main.benchmark}</a></div>    
     <input id="menu-toggle" type="checkbox"/>
@@ -18,18 +20,33 @@ export class HeaderComponent implements Component {
     </label>
     <ul class="menu">
       <li><a href="#dashboard" class="nav__link">${path.main.dashboard}</a></li>
+      ${!cookie ? `
       <li><a href="#signup" class="nav__link">${path.main.sign}</a></li>
       <li><a href="#login" class="nav__link">${path.main.login}</a></li>
+      `
+      : 
+      `
+      <li><a href="#main" class="nav__link log__out">${path.main.logout}</a></li>
+      `}
+
       <li><button class='nav__link change-lang-btn'>${btnInner}</button></li>
     </ul>
   </header>`;
   }
 
   static setListeners() {
-    const changeLangBtn: HTMLButtonElement | null = document.querySelector('.change-lang-btn');    
+    const changeLangBtn: HTMLButtonElement | null = document.querySelector('.change-lang-btn');  
+    const logOutBtn: HTMLAnchorElement | null = document.querySelector('.log__out');
     if (changeLangBtn) {
-      changeLangBtn!.addEventListener('click', () => {
+      changeLangBtn.addEventListener('click', () => {
         state.isEngl = !state.isEngl;
+        App.render();
+      });
+    }
+
+    if (logOutBtn){
+      logOutBtn.addEventListener('click', () => {
+        UsersService.removeCookie();
         App.render();
       });
     }

--- a/src/components/pages/dashboard/dashboard.scss
+++ b/src/components/pages/dashboard/dashboard.scss
@@ -174,6 +174,15 @@
   height: 70%;
 }
 
+.perma-link{
+  color: rgb(93, 93, 219);
+  cursor: pointer;
+  &:hover{
+    text-decoration: underline;
+  }
+}
+
+
 
 @media (max-width: 890px) {
   

--- a/src/utils/guestUser.ts
+++ b/src/utils/guestUser.ts
@@ -1,0 +1,10 @@
+import { UserData } from "./types";
+
+export class GuestUser implements UserData{
+  userName: string;
+  regDate: Date;
+  constructor(){
+    this.userName = "Guest";
+    this.regDate = new Date(new Date().getTime());
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,11 +35,11 @@ export interface User {
   permalink: string;
 }
 
-export interface UsersCookie{
-  userId: number,
+export interface UserData{
+  userId?: number,
   userName: string,
   regDate: Date,
-  permalink: string,
+  permalink?: string,
 }
 
 export interface PlayedTest {


### PR DESCRIPTION
- Добавил переключение кнопок LOGOUT и LOGIN\SIGNUP в зависимости от куки юзера.
- Если куки юзера пустой, то создается гостевая учетная запись и сахроняется в куки под именем "guest".
- В dashboard подгружаются имя пользователя и дата регистрации (только дата, функционал изменения времени с оригинала не реализован)
- Будучи авторизованным можно получить premalink по нажатию на соответствующую кнопку, в адресную строку поместится путь. Страничка перезагружается, но работает.
